### PR TITLE
Убрал необходимость использования raw string, пофиксил док-комментарии

### DIFF
--- a/tgverifier.go
+++ b/tgverifier.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 )
 
-// ErrInvalidCreds ...
-// Represents error in case of having invalid Telegram auth credentials
+// ErrInvalidCreds represents error in case of having invalid Telegram auth credentials
 var ErrInvalidCreds = errors.New("invalid telegram creds")
 
-// Credentials ...
-// Telegram Login credentials available for parsing from JSON.
+// Credentials are Telegram Login credentials available for parsing from JSON.
 type Credentials struct {
 	ID        int    `json:"id"`
 	FirstName string `json:"first_name"`
@@ -24,8 +22,7 @@ type Credentials struct {
 	Hash      string `json:"hash"`
 }
 
-// Verify ...
-// Checks if the credentials are from Telegram.
+// Verify checks if the credentials are from Telegram.
 // Returns nil error if credentials are from Telegram.
 func (c *Credentials) Verify(token []byte) error {
 	secret := sha256.Sum256(token)
@@ -42,37 +39,26 @@ func (c *Credentials) Verify(token []byte) error {
 	return nil
 }
 
-// String ...
-// Builds credentials string, excluding hash field.
+// String builds credentials string, excluding hash field.
 func (c *Credentials) String() string {
-	s := fmt.Sprintf(`auth_date=%d`, c.AuthDate)
+	s := fmt.Sprintf("auth_date=%d\n", c.AuthDate)
 
 	if c.FirstName != "" {
-		s += fmt.Sprintf(`
-first_name=%s`,
-			c.FirstName)
+		s += fmt.Sprintf("first_name=%s\n", c.FirstName)
 	}
 
-	s += fmt.Sprintf(`
-id=%d`,
-		c.ID)
+	s += fmt.Sprintf("id=%d\n", c.ID)
 
 	if c.LastName != "" {
-		s += fmt.Sprintf(`
-last_name=%s`,
-			c.LastName)
+		s += fmt.Sprintf("last_name=%s\n", c.LastName)
 	}
 
 	if c.PhotoURL != "" {
-		s += fmt.Sprintf(`
-photo_url=%s`,
-			c.PhotoURL)
+		s += fmt.Sprintf("photo_url=%s\n", c.PhotoURL)
 	}
 
 	if c.Username != "" {
-		s += fmt.Sprintf(`
-username=%s`,
-			c.Username)
+		s += fmt.Sprintf("username=%s", c.Username)
 	}
 
 	return s


### PR DESCRIPTION
Посмотрел в чем была проблема без использования сырой строки, удидел вот такое:

<img width="1413" alt="Screen Shot 2021-04-08 at 1 55 42 AM" src="https://user-images.githubusercontent.com/26854816/113933054-8fd48b00-980d-11eb-9c60-bcd379d243db.png">

Мы просто добавляли лишний `\n` в конце строки.

Протестировал вот так:
```go
func TestVerify(t *testing.T) {
	b := []byte(`{
    "id": 151272257,
    "first_name": "Амир",
    "last_name": "Муллагалиев",
    "username": "amirmullagaliev",
    "photo_url": "https://t.me/i/userpic/320/vnCWM1N8YDg12Q_m87JFNG9Ey2cy3YoOCCP6AkFkMfY.jpg",
    "auth_date": 1615827772,
    "hash": "71df938daeec09e0843bc37d766bf2d8e5efac14512d1ffb51263562c0e10a8e"
}`)

	var cred Credentials
	if err := json.Unmarshal(b, &cred); err != nil {
		log.Println(err)
	}

	if err := cred.Verify([]byte("token")); err != nil {
		t.Error("we are fucked up")
	}
}

```


